### PR TITLE
Fix typo in a directory name

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -12,7 +12,7 @@ Crystal 言語の[インストール](https://ja.crystal-lang.org/install/)が�
 
 ```sh
 $ cd <your favorite directory>
-$ git clone https://github.com/yuruhi/cr-bundle.git && cd cd-bundle
+$ git clone https://github.com/yuruhi/cr-bundle.git && cd cr-bundle
 $ shards build --release
 $ cp bin/cr-bundle <your favorite bin>
 ```

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ First you'll need to install [Crystal](https://crystal-lang.org/install/).
 
 ```sh
 $ cd <your favorite directory>
-$ git clone https://github.com/yuruhi/cr-bundle.git && cd cd-bundle
+$ git clone https://github.com/yuruhi/cr-bundle.git && cd cr-bundle
 $ shards build --release
 $ cp bin/cr-bundle <your favorite bin>
 ```


### PR DESCRIPTION
`cd cd-bundle`となっていて、`cd: no such file or directory: cd-bundle`となります。

```
$ git clone https://github.com/yuruhi/cr-bundle.git && cd cd-bundle
Cloning into 'cr-bundle'...
remote: Enumerating objects: 99, done.
remote: Counting objects: 100% (99/99), done.
remote: Compressing objects: 100% (53/53), done.
remote: Total 99 (delta 43), reused 92 (delta 40), pack-reused 0
Receiving objects: 100% (99/99), 14.71 KiB | 1.47 MiB/s, done.
Resolving deltas: 100% (43/43), done.
cd: no such file or directory: cd-bundle
```