### PR TITLE
Make cr-bundle buildable in older version of Crystal

### DIFF
--- a/src/bundler.cr
+++ b/src/bundler.cr
@@ -12,11 +12,11 @@ module CrBundle
       add_cr = path.basename.to_s + ".cr"
       if path.to_s.starts_with?(%r[\./|\.\./])
         if path.to_s.ends_with?("**")
-          return Dir.glob(Path[path.to_s + "/*"].expand(required_from.parent)).select { |s|
+          return Dir.glob(Path[path.to_s + "/*"].expand(required_from.parent).to_s).select { |s|
             File.file?(s)
           }.map { |s| Path[s] }.sort
         elsif path.to_s.ends_with?("*")
-          return Dir.glob(path.expand(required_from.parent)).select { |s|
+          return Dir.glob(path.expand(required_from.parent).to_s).select { |s|
             File.file?(s)
           }.map { |s| Path[s] }.sort
         else
@@ -30,13 +30,13 @@ module CrBundle
       else
         if path.to_s.ends_with?("**")
           return @options.paths.flat_map { |library_path|
-            Dir.glob(Path[path.to_s + "/*"].expand(library_path)).select { |s|
+            Dir.glob(Path[path.to_s + "/*"].expand(library_path).to_s).select { |s|
               File.file?(s)
             }.map { |s| Path[s] }
           }.sort
         elsif path.to_s.ends_with?("*")
           return @options.paths.flat_map { |library_path|
-            Dir.glob(path.expand(library_path)).select { |s|
+            Dir.glob(path.expand(library_path).to_s).select { |s|
               File.file?(s)
             }.map { |s| Path[s] }
           }.sort


### PR DESCRIPTION
I think supporting Crystal 0.33.0 ecosystem is beneficial, since 0.33.0 runtime is the only environment AtCoder supports.

These change make this project buildable in older version of Crystal, especially in 0.33.0.

I confirmed the test suite passes in the following Crystal versions.

* 0.33.0
* 0.36.1
* 1.0.0