### PR TITLE
Add executables and postinstall specification in shard.yml

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -13,3 +13,9 @@ targets:
 crystal: 0.36.1
 
 license: MIT
+
+scripts:
+  postinstall: shards build cr-bundle
+
+executables:
+  - cr-bundle


### PR DESCRIPTION
By adding these fields we can make sure that cr-bundle binary is built into the `bin` directory of the installed project.